### PR TITLE
Support connecting to k8s nodes via SSH

### DIFF
--- a/newbius/installations/example/main.tf
+++ b/newbius/installations/example/main.tf
@@ -92,6 +92,8 @@ module "k8s" {
 
   create_nlb = local.create_nlb
 
+  node_ssh_access_users = var.k8s_cluster_node_ssh_access_users
+
   providers = {
     nebius = nebius
     units  = units

--- a/newbius/installations/example/terraform.tfvars
+++ b/newbius/installations/example/terraform.tfvars
@@ -70,8 +70,10 @@ filestore_controller_spool = {
 # Shared filesystem to be used on controller, worker, and login nodes.
 # ---
 filestore_jail = {
-  size_gibibytes       = 2048
-  block_size_kibibytes = 4
+  spec = {
+    size_gibibytes       = 2048
+    block_size_kibibytes = 4
+  }
 }
 # Or use existing filestore.
 # ---

--- a/newbius/installations/example/terraform.tfvars
+++ b/newbius/installations/example/terraform.tfvars
@@ -154,13 +154,13 @@ k8s_cluster_node_group_gpu = {
 # SSH user credentials for accessing k8s nodes.
 # By default, empty list.
 # ---
-k8s_cluster_node_ssh_access_users = [{
-  name = "user1"
-  public_keys = [
-    "user1 key1",
-    "user1 key2",
-  ]
-}]
+# k8s_cluster_node_ssh_access_users = [{
+#   name = "user1"
+#   public_keys = [
+#     "user1 key1",
+#     "user1 key2",
+#   ]
+# }]
 
 # endregion k8s
 

--- a/newbius/installations/example/terraform.tfvars
+++ b/newbius/installations/example/terraform.tfvars
@@ -151,6 +151,17 @@ k8s_cluster_node_group_gpu = {
   }
 }
 
+# SSH user credentials for accessing k8s nodes.
+# By default, empty list.
+# ---
+k8s_cluster_node_ssh_access_users = [{
+  name = "user1"
+  public_keys = [
+    "user1 key1",
+    "user1 key2",
+  ]
+}]
+
 # endregion k8s
 
 # endregion Infrastructure

--- a/newbius/installations/example/variables.tf
+++ b/newbius/installations/example/variables.tf
@@ -206,6 +206,16 @@ variable "k8s_cluster_node_group_gpu" {
   }
 }
 
+variable "k8s_cluster_node_ssh_access_users" {
+  description = "SSH user credentials for accessing k8s nodes."
+  type = list(object({
+    name        = string
+    public_keys = list(string)
+  }))
+  nullable = false
+  default  = []
+}
+
 # endregion k8s
 
 # endregion Infrastructure

--- a/newbius/installations/example/variables.tf
+++ b/newbius/installations/example/variables.tf
@@ -87,7 +87,6 @@ variable "filestore_jail_submounts" {
       id = string
     }))
     spec = optional(object({
-      disk_type            = string
       size_gibibytes       = number
       block_size_kibibytes = number
     }))

--- a/newbius/modules/k8s/k8s_ng_cpu.tf
+++ b/newbius/modules/k8s/k8s_ng_cpu.tf
@@ -49,7 +49,10 @@ resource "nebius_mk8s_v1_node_group" "cpu" {
     }])
 
     network_interfaces = [{
+      public_ip_address = local.node_ssh_access.enabled ? {} : null
       subnet_id = var.vpc_subnet_id
     }]
+
+    cloud_init_user_data = local.node_ssh_access.enabled ? local.node_ssh_access.cloud_init_data : null
   }
 }

--- a/newbius/modules/k8s/k8s_ng_gpu.tf
+++ b/newbius/modules/k8s/k8s_ng_gpu.tf
@@ -88,7 +88,10 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
     }])
 
     network_interfaces = [{
+      public_ip_address = local.node_ssh_access.enabled ? {} : null
       subnet_id = var.vpc_subnet_id
     }]
+
+    cloud_init_user_data = local.node_ssh_access.enabled ? local.node_ssh_access.cloud_init_data : null
   }
 }

--- a/newbius/modules/k8s/k8s_ng_nlb.tf
+++ b/newbius/modules/k8s/k8s_ng_nlb.tf
@@ -34,6 +34,8 @@ resource "nebius_mk8s_v1_node_group" "nlb" {
       public_ip_address = {}
       subnet_id         = var.vpc_subnet_id
     }]
+
+    cloud_init_user_data = local.node_ssh_access.enabled ? local.node_ssh_access.cloud_init_data : null
   }
 }
 

--- a/newbius/modules/k8s/locals.tf
+++ b/newbius/modules/k8s/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  node_ssh_access = {
+    enabled = length(var.node_ssh_access_users) > 0
+    cloud_init_data = templatefile("${path.module}/templates/cloud_init.yaml.tftpl", {
+      ssh_users = var.node_ssh_access_users
+    })
+  }
+}

--- a/newbius/modules/k8s/templates/cloud_init.yaml.tftpl
+++ b/newbius/modules/k8s/templates/cloud_init.yaml.tftpl
@@ -1,0 +1,10 @@
+users:
+%{ for user in ssh_users ~}
+  - name: "${user.name}"
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+    %{~ for key in user.public_keys ~}
+      - "${key}"
+    %{~ endfor ~}
+%{ endfor ~}

--- a/newbius/modules/k8s/variables.tf
+++ b/newbius/modules/k8s/variables.tf
@@ -92,3 +92,14 @@ variable "create_nlb" {
   type     = bool
   nullable = false
 }
+
+#---
+
+variable "node_ssh_access_users" {
+  description = "SSH user credentials for accessing k8s nodes."
+  type = list(object({
+    name        = string
+    public_keys = list(string)
+  }))
+  default = []
+}


### PR DESCRIPTION
Connection to k8s nodes via SSH is crucial for diagnostics. Right now, we can only specify users and their public keys via cloud-init.

Dedicated fields are not going to be supported in near future by both mk8s and compute.